### PR TITLE
fix: restore sidebar refresh and delete ghost entries

### DIFF
--- a/api/unarchive_chat.py
+++ b/api/unarchive_chat.py
@@ -12,6 +12,14 @@ class UnarchiveChat(ApiHandler):
 
         found = unarchive_chat(chat_id)
 
+        # Trigger sidebar refresh so the restored chat reappears
+        if found:
+            try:
+                from helpers.state_monitor_integration import mark_dirty_all
+                mark_dirty_all(reason="chat_archive.unarchive")
+            except ImportError:
+                pass
+
         return {
             "ok": True,
             "chat_id": chat_id,

--- a/webui/archive-store.js
+++ b/webui/archive-store.js
@@ -78,8 +78,16 @@ const model = {
 
   async deleteArchivedChat(chatId) {
     try {
+      // First: remove from archive.json so ghost entries don't persist
+      await callJsonApi("/plugins/chat_archive/unarchive_chat", {
+        chat_id: chatId,
+      });
+
+      // Then: delete the chat context from the server
       const { sendJsonData } = await import("/index.js");
       await sendJsonData("/chat_remove", { context: chatId });
+
+      // Update local state
       const updated = { ...this.archived };
       delete updated[chatId];
       this.archived = updated;


### PR DESCRIPTION
## Problem

Two bugs prevent the archive modal from working correctly:

### Bug 1: Restore does not reappear in sidebar

`unarchive_chat.py` removes the chat from `archive.json` but never triggers a sidebar context refresh. The sidebar's `applyContexts` is patched to filter archived chats, but without `mark_dirty_all()` the server never pushes a fresh contexts list — so the restored chat stays hidden.

### Bug 2: Delete leaves ghost entries in archive.json

`deleteArchivedChat()` in `archive-store.js` calls `/chat_remove` to delete the chat from the server, but never removes the entry from `archive.json`. After page reload, the ghost entry reappears in the modal pointing to a chat that no longer exists.

## Fix

**api/unarchive_chat.py**: Added `mark_dirty_all()` call after successful unarchive to trigger sidebar context refresh (matching the pattern used by the core `chat_remove.py`).

**webui/archive-store.js**: `deleteArchivedChat()` now calls the unarchive API to clean `archive.json` before invoking `/chat_remove`, preventing ghost entries from persisting.

## Testing

- Verified Python syntax compiles cleanly
- Verified JS syntax with node -c
- Both patches are minimal (16 lines added) and follow existing framework patterns
